### PR TITLE
fix ubus lockup

### DIFF
--- a/libubus-internal.h
+++ b/libubus-internal.h
@@ -29,7 +29,7 @@ int __hidden __ubus_start_request(struct ubus_context *ctx, struct ubus_request 
 				struct blob_attr *msg, int cmd, uint32_t peer);
 void ubus_process_obj_msg(struct ubus_context *ctx, struct ubus_msghdr_buf *buf, int fd);
 void ubus_process_req_msg(struct ubus_context *ctx, struct ubus_msghdr_buf *buf, int fd);
-void __hidden ubus_poll_data(struct ubus_context *ctx, int timeout);
+void __hidden ubus_poll_single_datum(struct ubus_context *ctx, int timeout);
 
 
 #endif

--- a/libubus-io.c
+++ b/libubus-io.c
@@ -311,6 +311,8 @@ static bool get_next_msg(struct ubus_context *ctx, int *recv_fd)
 
 void __hidden ubus_handle_data(struct uloop_fd *u, unsigned int events)
 {
+	(void) events;
+
 	struct ubus_context *ctx = container_of(u, struct ubus_context, sock);
 	int recv_fd = -1;
 

--- a/libubus-req.c
+++ b/libubus-req.c
@@ -160,7 +160,7 @@ int ubus_complete_request(struct ubus_context *ctx, struct ubus_request *req,
 			}
 		}
 
-		ubus_poll_data(ctx, (unsigned int) timeout);
+		ubus_poll_single_datum(ctx, (unsigned int) timeout);
 
 		if (ctx->sock.eof) {
 			ubus_set_req_status(req, UBUS_STATUS_CONNECTION_FAILED);


### PR DESCRIPTION
It is possible for `ubus_complete_request` to be nested.
Without this patch, this can lead to a state where only the innermost call to `ubus_handle_data` returns.
This means the execution is stuck in `ubus_complete_request`. Not only does this starve all activity outside the ubus socket (event loop), any invoke/unsubscribe/notify message will only be queued up and never handled.

I've collected some details over in https://github.com/openwrt/openwrt/issues/14573 but beware: I have a nasty cold and I'm not in the best state of mind.
The synopsis is: Noticed hostapd not reacting to invokes. Dug around to find that one ubus context didn't have its `stack_depth` reduced below one. A `lookup_id` for `"service"` being the one that never returned despite its data having been handled. The calling code is hostapd.uc/ucode-ubus.

The bug reproduces relatively well (~50% after a /etc/init.d/wpad restart) when there is a mesh network (the lookup for `"wpa_supplicant"` has a good timing) and four access point SSIDs.
Being a race, CPU speed also matters. I've been seeing this reliably on mt7621 (Cudy M1800) and mt7981b (Cudy M3000, Yuncore AX835).