### PR TITLE
lua: Implement object removal

### DIFF
--- a/lua/ubus.c
+++ b/lua/ubus.c
@@ -577,9 +577,9 @@ static int ubus_lua_add(lua_State *L)
 				ubus_add_object(c->ctx, obj);
 
                                 /* allow future reference of ubus obj */
-				lua_pushstring(state,"__ubusobj");
-				lua_pushlightuserdata(state, obj);
-				lua_settable(state,-3);
+				lua_pushstring(L,"__ubusobj");
+				lua_pushlightuserdata(L, obj);
+				lua_settable(L,-3);
                         }
 		}
 		lua_pop(L, 1);


### PR DESCRIPTION
When implementing services in Lua, some objects on the bus might need to
disappear, but there is no way to disappear them with the current
implementation.

Signed-off-by: Ernestas Kulik <ernestas.k@iconn-networks.com>