### PR TITLE
CMakeLists.txt: bump minimum cmake version in all CMakeLists.txt files

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.13)
 
 ADD_DEFINITIONS(-I..)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.13)
 
 PROJECT(ubus C)
 


### PR DESCRIPTION
Removes error when building with cmake >= v4.0.0, since that version removed compatibility with cmake version older than 3.5.

https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features