### PR TITLE
ubusd: avoid client_cb stalls after short reads

### DIFF
--- a/ubusd_main.c
+++ b/ubusd_main.c
@@ -139,15 +139,17 @@ retry:
 		}
 
 		bytes = recvmsg(sock->fd, &msghdr, 0);
-		if (bytes < 0)
+		if (bytes <= 0)
 			goto out;
 
 		if (*pfd >= 0)
 			cl->pending_msg_fd = *pfd;
 
 		cl->pending_msg_offset += bytes;
-		if (cl->pending_msg_offset < (int) sizeof(cl->hdrbuf))
-			goto out;
+		if (cl->pending_msg_offset < (int) sizeof(cl->hdrbuf)) {
+			/* Keep draining; edge-triggered uloop may not fire again. */
+			goto retry;
+		}
 
 		if (blob_raw_len(&cl->hdrbuf.data) < sizeof(struct blob_attr))
 			goto disconnect;
@@ -179,7 +181,8 @@ retry:
 
 		if (bytes < len) {
 			cl->pending_msg_offset += bytes;
-			goto out;
+			/* Keep draining; edge-triggered uloop may not fire again. */
+			goto retry;
 		}
 
 		/* accept message */


### PR DESCRIPTION
This fixes a rare receive stall in `ubusd` `client_cb()`.

client sockets are registered with `ULOOP_EDGE_TRIGGER`. A short positive `recvmsg()`/`read()` can leave unread data in the socket buffer, but the current code returns to the event loop and assumes another readable event will arrive. With edge-triggered polling, that is not guaranteed if no additional data arrives to create another readiness edge.

Retry the receive path immediately after making progress on an incomplete header/body read. Also treat `recvmsg() == 0` as no progress/EOF to avoid retrying on a closed connection.